### PR TITLE
Update getCylinderInertia function

### DIFF
--- a/calc_inertia_for_urdf.py
+++ b/calc_inertia_for_urdf.py
@@ -99,7 +99,7 @@ def getSphereInertia(r, m):
     return i, i, i
 
 def getCylinderInertia(r, h, m):
-    xx = yy = 1./12 * (3 * r**2 + h**2)
+    xx = yy = 1./12 * m * (3 * r**2 + h**2)
     zz = 1./2 * m * r**2
     return xx, yy, zz
 


### PR DESCRIPTION
Update getCylinderInertia function in calc_inertia_for_urdf.py.
![Screenshot from 2022-11-02 12-22-06](https://user-images.githubusercontent.com/75611653/199452972-09bbc4a2-c1b6-49d2-bf0d-a4a1b5e3d37e.png)

xx = yy = 1./12 * (3 * r ** 2 + h ** 2). I added to m parameter as: xx = yy = 1./12 * **m** * (3 * r ** 2 + h **2 )